### PR TITLE
fix: explosion sound not playing

### DIFF
--- a/Assests/Javascript/game.js
+++ b/Assests/Javascript/game.js
@@ -31,7 +31,13 @@ const pi = 3.14159;
 var paused = 0;
 const themesound = new Audio("Assests/Sounds/theme.mp3");
 const fire_audio = new Audio("Assests/Sounds/fire.mp3");
-const explosion_audio = new Audio("Assests/Sounds/explosion.mp3");
+
+var playingSounds = []
+
+function explosion_audio(){
+  playingSounds.push(new Audio("Assests/Sounds/explosion.mp3"))
+  playingSounds[playingSounds.length-1].play()
+}
 
 bombplacement();
 health_bar_update();
@@ -134,7 +140,7 @@ function explode(x) {
     explosion.style.right = x + "vw";
   }
   explosion.style.display = "block";
-  explosion_audio.play();
+  explosion_audio();
   window.setTimeout(function () {
     explosion.style.display = "none";
   }, 2000);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Pocket_Tanks
+Pocket Tanks game made from HTML,CSS and JS
+
+The game is a Rip-Off of the original game of the same name.
+The game is entirely made of Vanilla HTML CSS and JavaScript.


### PR DESCRIPTION
Fixed Bug: The explosion sound was not playing sometimes if both tanks were at angle 10 and shooting with normal to low power

How to reproduce currently: 
1. lower the angle to 10 whenever possible
2. spam enter
Then some explosion sounds will not play because they are overlapping

